### PR TITLE
Feature: add .exec() command and make requests use credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ dpd.categories.put(id, {..},function(result){ ... });
 
 // will delete a category from the the database and on success will delete it from the cache
 dpd.categories.del(id,function(){ ... });
+
+// login a user
+dpd.users.exec('login', { username: 'user', password: 'pass' }).success(function(session) { }).error(function(err) { });
 ```
 
 Here is an example where you can query objects from the table and immediately put them on the screen.

--- a/README.md
+++ b/README.md
@@ -10,75 +10,122 @@ This allows you to quickly wire up your angular app with deployd and keep all of
 Example usage
 ---------------------
 
-	var app = angular.module('myApp',['dpd']);
+```javascript
+var app = angular.module('myApp',['dpd']);
 
- 	app.value('dpdConfig',['categories']);
+// Configuration:
+app.value('dpdConfig',['categories']);
+// or
+app.value('dpdConfig', { 
+	collections: ['categories'], 
+	serverRoot: 'http://someotherserver.com/', // optional, defaults to same server
+	socketOptions: { reconnectionDelayMax: 3000 }, // optional socket io additional configuration
+	useSocketIo: true // optional, defaults to false
+	noCache: true // optional, defaults to false (false means that caching is enabled, true means it disabled)
+});
 
- 	app.controller('bodyController',function($scope, dpd){
 
-		dpd.categories.get();
-		
-        dpd.categories.get('414b9c5cc315485d');
-        
-        // Example with an [advanced query](http://docs.deployd.com/docs/collections/reference/querying-collections.md#s-Advanced%20Queries-2035):
-        dpd.categories.get($sort: {name: 1}, $limit: 10, rightsLevel: {$gt:0}};
-		
-		dpd.categories.post({"value":"cat1","typeId":"987ad2e6d2bdaa9d"});
-		
-		dpd.categories.put('414b9c5cc315485d',{"value":"cat123"});
-		
-		dpd.categories.del('414b9c5cc315485d');
-		
-		dpd.categories.save({"value":"save POST","typeId":"987ad2e6d2bdaa9d"},function(result){
-		
-			result.value = "save PUT";
-			
-			dpd.categories.save(result);
+app.controller('bodyController',function($scope, dpd){
+
+	dpd.categories.get();
+	
+	dpd.categories.get('414b9c5cc315485d');
+	
+	// Example with an [advanced query](http://docs.deployd.com/docs/collections/reference/querying-collections.md#s-Advanced%20Queries-2035):
+	dpd.categories.get($sort: {name: 1}, $limit: 10, rightsLevel: {$gt:0}};
+	
+	// Promises are supported:
+	dpd.categories.post({"value":"cat1","typeId":"987ad2e6d2bdaa9d"})
+		.success(function (result) {
+			// use result
+		})
+		.error(function (err) {
+			// on error
+		})
+		.finally(function () {
+			// finally
 		});
 	
+	dpd.categories.put('414b9c5cc315485d',{"value":"cat123"});
+	
+	dpd.categories.del('414b9c5cc315485d');
+	
+	// You can also use a callback instead of using promises if you prefer:
+	dpd.categories.save({"value":"save POST","typeId":"987ad2e6d2bdaa9d"},function(result){
+	
+		result.value = "save PUT";
+		
+		dpd.categories.save(result);
 	});
 
+});
+```
 
 Cache
 ---------------------
 
-This comes with a cache object that will persist after calling a get().
-	
-	// will return every category that is currently in the cache
-	dpd.categories.cache.all 
+Unless caching is disabled via configuration, the dpd object comes with a cache object that will persist after calling a get().
 
-	// will return a specific category from the cache
-	dpd.categories.cache.get('414b9c5cc315485d') 
+```javascript	
+// will return every category that is currently in the cache
+dpd.categories.cache.all 
 
-	// will fetch a single category from the database and if it's in the cache, update the cached item.
-	// If it's not in the cache it will be added.
-	dpd.categories.get(id,function(result){ ... });
-	
-	// will add a new category to the the database and on success will add it to the cache
-	dpd.categories.post({..},function(result){ ... });
+// will return a specific category from the cache
+dpd.categories.cache.get('414b9c5cc315485d') 
 
-	// will update a category in the the database and on success will update it in the cache 
-	// If it's not in the cache it will be added.
-	dpd.categories.put(id, {..},function(result){ ... });
+// will fetch a single category from the database and if it's in the cache, update the cached item.
+// If it's not in the cache it will be added.
+dpd.categories.get(id,function(result){ ... });
 
-	// will delete a category from the the database and on success will delete it from the cache
-	dpd.categories.del(id,function(){ ... });
+// will add a new category to the the database and on success will add it to the cache
+dpd.categories.post({..},function(result){ ... });
 
+// will update a category in the the database and on success will update it in the cache 
+// If it's not in the cache it will be added.
+dpd.categories.put(id, {..},function(result){ ... });
+
+// will delete a category from the the database and on success will delete it from the cache
+dpd.categories.del(id,function(){ ... });
+```
 
 Here is an example where you can query objects from the table and immediately put them on the screen.
 
-	<!DOCTYPE html>
-	<html ng-app="myApp">
-		<head>
-			<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.6/angular.min.js"></script>
-			<script type="text/javascript" src="angular-dpd/angular-dpd.js"></script>
-			<script type="text/javascript" src="app.js"></script>
-		</head>
-		<body ng-controller="bodyController">
-			<ul ng-init="dpd.categories.get()">
-				<li ng-repeat="c in dpd.categories.cache.all">
-					{{c.value}}
-				</li>
-			</ul>
-		</body>
-	</html>
+```html
+<!DOCTYPE html>
+<html ng-app="myApp">
+	<head>
+		<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.6/angular.min.js"></script>
+		<script type="text/javascript" src="angular-dpd/angular-dpd.js"></script>
+		<script type="text/javascript" src="app.js"></script>
+	</head>
+	<body ng-controller="bodyController">
+		<ul ng-init="dpd.categories.get()">
+			<li ng-repeat="c in dpd.categories.cache.all">
+				{{c.value}}
+			</li>
+		</ul>
+	</body>
+</html>
+```
+	
+Socket.IO
+---------------------
+
+If socket.io is enabled in the configuration, it can be used like this:
+
+```javascript
+app.controller('bodyController',function($scope, dpd){
+	dpd.categories.on($scope, "changed", function (result) { // this handles "categories:changed"
+		console.log("event fired");
+	}
+	// or
+	dpd.on($scope, "categories:changed", function (result) {
+		console.log("event fired");
+	}
+}
+```
+
+For low-level access, the raw socket is exposed as `dpd.socket.rawSocket`.
+
+Note: We inject $scope in the call so that the library can automatically remove the events if the $scope is $destroyed (such as when a route change occurs).
+	

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dpd-angular-cache
+angular-dpd
 =================
 
 A plugin for Angular that allows for easy interaction with deployd.
@@ -6,6 +6,8 @@ Usage is the same as the default dpd.js file, but requires configuration of the 
 Extra 'save' helper function added that will POST if the object has no 'id' and will put if it does.
 Also includes a cache for your objects that have been retrieved for easy insertion into the DOM.
 This allows you to quickly wire up your angular app with deployd and keep all of your files static so the deployd api can spend it's time serving data instead of a dynamic .js file.
+
+Forked from: https://github.com/slively/dpd-angular-cache
 
 Example usage
 ---------------------

--- a/angular-dpd.js
+++ b/angular-dpd.js
@@ -98,7 +98,7 @@ angular.module('dpd', []).value('dpdConfig', [])
             }
             dpd[d].get = function(o, s, e) {
                 if (typeof o == "string") {
-                    return $http.get(serverRoot + '/' + d + '/' + o).success(function(data, status, headers, config) {
+                    return $http.get(serverRoot + '/' + d + '/' + o, { withCredentials: true }).success(function(data, status, headers, config) {
                         if (!dpd[d].cache) return;
                         var add = true;
                         for (var i in dpd[d].cache.all) {
@@ -114,20 +114,21 @@ angular.module('dpd', []).value('dpdConfig', [])
                     if (typeof o == "function") {
                         e = s;
                         s = o;
-                        return $http.get(serverRoot + '/' + d).success(function(data, status, headers, config) {
+                        return $http.get(serverRoot + '/' + d, { withCredentials: true }).success(function(data, status, headers, config) {
                             if (!dpd[d].cache) return;
                             dpd[d].cache.all = data;
                         }).success(checkUndefinedFunc(s)).error(ef).error(checkUndefinedFunc(e));
                     } else {
                         if (isComplexQuery(o)) {
                             var query = encodeURI(JSON.stringify(o));
-                            return $http.get(serverRoot + '/' + d + '?' + query).success(function(data, status, headers, config) {
+                            return $http.get(serverRoot + '/' + d + '?' + query, { withCredentials: true }).success(function(data, status, headers, config) {
                                 if (!dpd[d].cache) return;
                                 dpd[d].cache.all = data;
                             }).success(checkUndefinedFunc(s)).error(ef).error(checkUndefinedFunc(e));
                         } else {
                             return $http.get(serverRoot + '/' + d, {
-                                params: o
+                                params: o,
+                                withCredentials: true
                             }).success(function(data, status, headers, config) {
                                 if (!dpd[d].cache) return;
                                 dpd[d].cache.all = data;
@@ -138,7 +139,7 @@ angular.module('dpd', []).value('dpdConfig', [])
             };
 
             dpd[d].put = function(id, o, s, e) {
-                return $http.put(serverRoot + '/' + d + '/' + id, o).success(function(data, status, headers, config) {
+                return $http.put(serverRoot + '/' + d + '/' + id, o, { withCredentials: true }).success(function(data, status, headers, config) {
                     if (!dpd[d].cache) return;
                     var add = true;
                     for (var i in dpd[d].cache.all) {
@@ -153,14 +154,14 @@ angular.module('dpd', []).value('dpdConfig', [])
             };
 
             dpd[d].post = function(o, s, e) {
-                return $http.post(serverRoot + '/' + d + '/', o).success(function(data, status, headers, config) {
+                return $http.post(serverRoot + '/' + d + '/', o, { withCredentials: true }).success(function(data, status, headers, config) {
                     if (!dpd[d].cache) return;
                     dpd[d].cache.all.push(data);
                 }).success(checkUndefinedFunc(s)).error(ef).error(checkUndefinedFunc(e));
             };
 
             dpd[d].del = function(id, s, e) {
-                return $http.delete(serverRoot + '/' + d + '/' + id).success(function(data, status, headers, config) {
+                return $http.delete(serverRoot + '/' + d + '/' + id, { withCredentials: true }).success(function(data, status, headers, config) {
                     if (!dpd[d].cache) return;
                     for (var i in dpd[d].cache.all) {
                         if (dpd[d].cache.all[i].id == id) {
@@ -177,6 +178,10 @@ angular.module('dpd', []).value('dpdConfig', [])
                     dpd[d].post(obj, s, e);
                 }
             };
+            
+            dpd[d].exec = function (func, o, s, e) {
+                return $http.post(serverRoot + '/' + d + '/' + func, o, { withCredentials: true }).success(checkUndefinedFunc(s)).error(ef).error(checkUndefinedFunc(e));                
+            }
 
             dpd[d].on = function(scope, event, f) {
                 if (!dpdSocket) return;

--- a/angular-dpd.js
+++ b/angular-dpd.js
@@ -3,9 +3,9 @@
 var angularDpdSockets = [];
 
 angular.module('dpd', []).value('dpdConfig', [])
-    .factory('dpdSocket', function($rootScope, dpdConfig) {
+    .factory('dpdSocket', ['$rootScope', 'dpdConfig', function($rootScope, dpdConfig) {
         if (!dpdConfig.useSocketIo) {
-            return false;
+            return undefined;
         }
         if (!io.connect) {
             throw ('angular-dpd: socket.io library not available, includ the client library or set dpdConfig.useSocketIo = false');
@@ -38,8 +38,8 @@ angular.module('dpd', []).value('dpdConfig', [])
             },
             rawSocket: socket
         };
-    })
-    .factory('dpd', function($http, $rootScope, dpdConfig, dpdSocket) {
+    }])
+    .factory('dpd', ['$http', '$rootScope', 'dpdConfig', 'dpdSocket', function($http, $rootScope, dpdConfig, dpdSocket) {
         var dpd = {};
         dpd.errors = [];
         dpd.socket = dpdSocket;
@@ -202,4 +202,4 @@ angular.module('dpd', []).value('dpdConfig', [])
         
         $rootScope.dpd = dpd;
         return dpd;
-    });
+    }]);


### PR DESCRIPTION
The session id cookie (sid) wouldn't be passed to requests unless the withCredentials options was passed to $http.

See: See http://stackoverflow.com/questions/19383311/angularjs-http-does-not-seem-to-understand-set-cookie-in-the-response