### PR TITLE
The user that not include socket.io can't use the script 

### DIFF
--- a/angular-dpd.js
+++ b/angular-dpd.js
@@ -5,7 +5,7 @@ var angularDpdSockets = [];
 angular.module('dpd', []).value('dpdConfig', [])
     .factory('dpdSocket', ['$rootScope', 'dpdConfig', function($rootScope, dpdConfig) {
         if (!dpdConfig.useSocketIo) {
-            return undefined;
+            return {};
         }
         if (!io.connect) {
             throw ('angular-dpd: socket.io library not available, includ the client library or set dpdConfig.useSocketIo = false');


### PR DESCRIPTION
If a user will not use socket.io, then he has to desactivate it in the 'dpdConfig', but when enter to the definition of dpdSocket Factory, the, the execution enter inside the first if and return undefined. This must be throw an error because we are defining here a factory and we have to return always an object. So a solution here is return a empty object, instead undefined